### PR TITLE
[zkDOOM] Removed .clone() on frames, improved cycle perf

### DIFF
--- a/zkdoom/methods/guest/src/main.rs
+++ b/zkdoom/methods/guest/src/main.rs
@@ -321,10 +321,10 @@ impl GameMonitor {
         }
     }
 
-    fn finalize(&self) {
+    fn finalize(&mut self) {
         unsafe {
             let output = OutputData {
-                frames: self.frames.clone(), // TODO resolve this clone
+                frames: std::mem::take(&mut self.frames),
                 gametics: puredoom_rs::gametic as u32,
             };
             env::commit(&output);


### PR DESCRIPTION
This PR swaps .clone() for std::mem::take() and saves a few megacycles depending on frame counts commited.

Using: `--frame-mode=1 -u 4`

Before:
`total cycles: 145752064`

After:
`total cycles: 142737408`