### PR TITLE
MacOS: fix build by pinning `cc` crate

### DIFF
--- a/zkdoom/host/Cargo.toml
+++ b/zkdoom/host/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+# cc crate version 1.0.06 is broken on macOS delete this pin when they publish a new version
+cc = "=1.0.83"
 clap = { version = "4.3.0", features = ["derive"] }
 image = "0.24.8"
 puredoom-rs = { path = "../puredoom-rs" }


### PR DESCRIPTION
upstream maintainers are currently working on a fix so we can remove this pin when they publish a version with the fix.