### PR TITLE
Add version notes to demos

### DIFF
--- a/bonsai-pay/README.md
+++ b/bonsai-pay/README.md
@@ -21,15 +21,8 @@ curl https://sh.rustup.rs -sSf | sh
 curl -L https://foundry.paradigm.xyz | bash
 ```
 
-Next, you will need to install the `cargo risczero` tool.
-We'll use [`cargo binstall`][cargo-binstall] to get `cargo-risczero` installed, and then install the `risc0` toolchain.
-See [RISC Zero installation] for more details.
-
-```sh
-cargo install cargo-binstall
-cargo binstall cargo-risczero
-cargo risczero install
-```
+Next, use the [RISC Zero installation] instructions to install `v0.21` of the RISC Zero zkVM. 
+> Note: This demo only works with `v0.21`.
 
 ### Google Cloud Platform
 

--- a/near-zk-light-client/README.md
+++ b/near-zk-light-client/README.md
@@ -12,15 +12,14 @@ Generating a ZK proof of the light client verification is ideal in this case, es
 
 ## Quick Start
 
-First, make sure [rustup] is installed. The
-[`rust-toolchain.toml`][rust-toolchain] file will be used by `cargo` to
-automatically install the correct version.
+First, [install] `v0.20` of the RISC Zero zkVM. 
+> Note: This demo only works with `v0.20`.
 
 To build all methods and execute the method within the zkVM, run the following
 command:
 
 ```bash
-cargo run
+cargo run 
 ```
 
 This is an empty template, and so there is no expected output (until you modify
@@ -91,6 +90,7 @@ We'd love to hear from you on [Discord][discord] or [Twitter][twitter].
 [discord]: https://discord.gg/risczero
 [docs.rs]: https://docs.rs/releases/search?query=risc0
 [examples]: https://github.com/risc0/risc0/tree/main/examples
+[install]: https://dev.risczero.com/api/zkvm/install
 [risc0-build]: https://docs.rs/risc0-build
 [risc0-repo]: https://www.github.com/risc0/risc0
 [risc0-zkvm]: https://docs.rs/risc0-zkvm

--- a/zk-kyc/README.md
+++ b/zk-kyc/README.md
@@ -26,15 +26,8 @@ curl https://sh.rustup.rs -sSf | sh
 curl -L https://foundry.paradigm.xyz | bash
 ```
 
-Next, you will need to install the `cargo risczero` tool.
-We'll use [`cargo binstall`][cargo-binstall] to get `cargo-risczero` installed, and then install the `risc0` toolchain.
-See [RISC Zero installation] for more details.
-
-```sh
-cargo install cargo-binstall
-cargo binstall cargo-risczero
-cargo risczero install
-```
+Next, use the [RISC Zero installation] instructions to install `v0.21` of the RISC Zero zkVM. 
+> Note: This demo only works with `v0.21`.
 
 ### ID.me Developer Account
 

--- a/zkdoom/README.md
+++ b/zkdoom/README.md
@@ -20,6 +20,8 @@ This will install a version of clang that supports RISC-V targets.
 
 ## Run
 
+> To run the example, you'll need to [update your zkVM installation] to use `v0.20`.
+
 Run the zkDOOM system with a input demo file (lmp), emit the frames to /tmp/ and run for 30 update iterations
 
 Please have `CC` set to clang, currently we don't support building this project with gcc
@@ -53,3 +55,5 @@ convert -delay 20 -loop 0 `ls -v /tmp/frame*.jpg` /tmp/zkdoom.gif
 https://classicdoom.com/d1demos.htm#e1m5
 
 WARNING: You need to make sure your demo files match the contents of the WAD. So the doom1.wad shareware version only contains a limited few maps so only select demos will work.
+
+[update your zkVM installation]: https://dev.risczero.com/api/zkvm/install#install


### PR DESCRIPTION
This PR addresses #31 by adding a note about zkVM version requirements to the README for each demo. 

I've also removed the granular installation instructions in favor of pointing to the [installation instructions](https://dev.risczero.com/api/zkvm/install) as a stable source of truth. 