### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/near-zk-light-client/README.md
+++ b/near-zk-light-client/README.md
@@ -96,6 +96,6 @@ We'd love to hear from you on [Discord][discord] or [Twitter][twitter].
 [risc0-zkvm]: https://docs.rs/risc0-zkvm
 [rustup]: https://rustup.rs
 [rust-toolchain]: rust-toolchain.toml
-[twitter]: https://twitter.com/risczero
+[twitter]: https://x.com/risczero
 [zkvm-overview]: https://dev.risczero.com/zkvm
 [zkhack-iii]: https://www.youtube.com/watch?v=Yg_BGqj_6lg&list=PLcPzhUaCxlCgig7ofeARMPwQ8vbuD6hC5&index=5

--- a/zk-socials/social_validator/README.md
+++ b/zk-socials/social_validator/README.md
@@ -107,6 +107,6 @@ We'd love to hear from you on [Discord][discord] or [Twitter][twitter].
 [risc0-zkvm]: https://docs.rs/risc0-zkvm
 [rustup]: https://rustup.rs
 [rust-toolchain]: rust-toolchain.toml
-[twitter]: https://twitter.com/risczero
+[twitter]: https://x.com/risczero
 [zkvm-overview]: https://dev.risczero.com/zkvm
 [zkhack-iii]: https://www.youtube.com/watch?v=Yg_BGqj_6lg&list=PLcPzhUaCxlCgig7ofeARMPwQ8vbuD6hC5&index=5


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.